### PR TITLE
Migrate github_sample functionality from Jekyll to Hugo

### DIFF
--- a/website/www/site/layouts/shortcodes/github_sample.html
+++ b/website/www/site/layouts/shortcodes/github_sample.html
@@ -1,0 +1,24 @@
+{{ $githubApiUrl := "https://api.github.com/repos" }}
+{{ $path := .Get 0 }}
+{{ $tag := .Get 1 }}
+
+{{ $path := replaceRE "/blob/" "/contents/" $path }}
+{{ $path := replaceRE "((/.*?){3})/(.*?)(/.*)" "$1$4?ref=$3" $path }}
+{{ $resp := getJSON $path }}
+{{ $data := $resp.content | base64Decode | htmlUnescape | safeHTML }}
+
+{{ $matchRegex := printf "%s%s%s%s%s" "\\[START " $tag "]\n[\\s\\S]*?\n.*\\[END " $tag "]" }}
+{{ $match := index (findRE $matchRegex $data) 0 }}
+
+{{ $lines := split $match "\n" }}
+{{ $lineCount := len $lines }}
+{{ $cleanedLines := $lines | first (sub $lineCount 1) | last (sub $lineCount 2) }}
+
+{{ $firstLine := index $cleanedLines 0 }}
+{{ $numberOfWhitespaces := index (findRE "^\\s*" $firstLine) 0 | len }}
+{{ $unindentRegex := printf "%s%d%s" "^\\s{" $numberOfWhitespaces "}" }}
+
+{{ $unindentedLines := apply $cleanedLines "replaceRE" $unindentRegex "" "." }}
+
+{{ $result := delimit $unindentedLines "\n" }}
+{{ print $result }}

--- a/website/www/site/layouts/shortcodes/github_sample.html
+++ b/website/www/site/layouts/shortcodes/github_sample.html
@@ -4,8 +4,10 @@
 
 {{ $path := replaceRE "/blob/" "/contents/" $path }}
 {{ $path := replaceRE "((/.*?){3})/(.*?)(/.*)" "$1$4?ref=$3" $path }}
-{{ $resp := getJSON $path }}
-{{ $data := $resp.content | base64Decode | htmlUnescape | safeHTML }}
+{{ $url := printf "%s%s" $githubApiUrl $path }}
+
+{{ $resp := getJSON $url }}
+{{ $data := $resp.content | base64Decode }}
 
 {{ $matchRegex := printf "%s%s%s%s%s" "\\[START " $tag "]\n[\\s\\S]*?\n.*\\[END " $tag "]" }}
 {{ $match := index (findRE $matchRegex $data) 0 }}

--- a/website/www/site/layouts/shortcodes/highlight.html
+++ b/website/www/site/layouts/shortcodes/highlight.html
@@ -10,7 +10,7 @@
  limitations under the License. See accompanying LICENSE file.
 */}}
 
-{{ $content := .Inner }}
+{{ $content := .Inner | htmlUnescape | safeHTML }}
 {{ $ctx := . }}
 {{ with (.Get "class") }}
     <div class={{ . }}>


### PR DESCRIPTION
Usage: 

```
{{< github_sample /path/to/file selected_tag >}}
```

Example:
```
{{< github_sample "/apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py" examples_wordcount_minimal_options >}}
```